### PR TITLE
0.5.4 fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,7 @@ The following software must be installed on your system before installing the Fe
 
 ### Mozilla Firefox
 
-If you use the [Mozilla Firefox](http://getfirefox.com/) web browser (version 12.0 or higher), ensure you have the [Greasemonkey extension](https://addons.mozilla.org/en-US/firefox/addon/greasemonkey/) installed (at version 1.0 or higher).
+If you use the [Mozilla Firefox](http://getfirefox.com/) web browser (version 12.0 or higher), ensure you have the [Tampermonkey extension](https://addons.mozilla.org/nl/firefox/addon/tampermonkey/) installed (at version 1.0 or higher).
 
 ### Google Chrome
 
@@ -26,7 +26,7 @@ If you use the [Google Chrome](https://chrome.google.com/) web browser (version 
 
 ## Installing
 
-To install FetLife Age/Sex/Location Search, go to [https://github.com/Ornias1993/fetlife-aslsearch-reborn/](https://github.com/Ornias1993/fetlife-aslsearch-reborn/releases) and copy the content to a new "GreaseMonkey" or "Tamper Monkey" script.
+To install FetLife Age/Sex/Location Search, go to [https://github.com/Ornias1993/fetlife-aslsearch-reborn/](https://github.com/Ornias1993/fetlife-aslsearch-reborn/releases) and copy the content to a new "Tamper Monkey" script.
 
 > [Download and install FetLife Age/Sex/Location Search](https://github.com/Ornias1993/fetlife-aslsearch-reborn/blob/master/fetlife-age-sex-location-search.user.js)
 

--- a/README.markdown
+++ b/README.markdown
@@ -88,6 +88,15 @@ Still, in a trigger-happy legal environment where people eagerly sue over spille
 That said, since this script is public domain, it's entirely use-at-your-own-risk. There's no warranty or customer service or anything like that, but I'll happily refund the $0 you paid for it. ;)
 
 ## Change log
+* Version 0.5.4
+    * [Feature Hidden](https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/7): Legacy search is hidden due to fetlife banhammer and numerous bugs
+    * [Bugfix](https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/15): Fixed processing of Avatar url's for extended search. Still cant display them in results
+    * [Misc] (https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/17): Replaced FAADE report with "Report User to Caretakes" in search results
+    * [Bugfix](https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/18): Fixed Country and Region mixup during scraping and database corrupt. Database will recover in time.
+    * [Documentation](https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/20): Pointed towards tampermonkey instead of greasemonkey due to compatibility issues
+    * update: Updated and consolidated server Scripts and (external) CSS
+* Version 0.5.3
+    * [Bugfix](https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/10): Fixes Extended search not showing inside plugin/script
 * Version 0.5.2
     * [Bugfix](https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/9): Fixes GUI glitches
 * Version 0.5.1

--- a/fetlife-age-sex-location-search.user.js
+++ b/fetlife-age-sex-location-search.user.js
@@ -24,7 +24,6 @@
 // @grant          GM_openInTab
 // ==/UserScript==
 
-
 FL_UI = {}; // FetLife User Interface module
 FL_UI.Text = {
     'donation_appeal': '<br><hr><p>FetLife ASL Search is provided as free software, but sadly grocery stores do not offer free food. If you like this script, please consider <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=kjeld@schouten-lebbing.nl&amount=&item_name=FetLife%20ASL%20Search">making a donation</a> to support its continued development. &hearts; Thank you. :)</p><hr><Br><br>'
@@ -1123,13 +1122,22 @@ FL_ASL.scrapeProfile = function (user_id) {
     return profile_data;
 }
 FL_ASL.scrapeUserInList = function (node) {
-    // TODO Deal with location inconsistencies.
+    console.log("Scraping user from List");
     var loc_parts = jQuery(node).find('.fl-member-card__location').first().text().split(', ');
     var locality = ''; var region = ''; var country = '';
     if (2 === loc_parts.length) {
+      var countries = ['Afghanistan', 'Aland', 'Islands', 'Albania', 'Algeria', 'American', 'Samoa', 'Andorra', 'Angola', 'Anguilla', 'Antarctica', 'Antigua', 'and', 'Barbuda', 'Argentina', 'Armenia', 'Aruba', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados', 'Belarus', 'Belgium', 'Belize', 'Benin', 'Bermuda', 'Bhutan', 'Bolivia', 'Bonaire', 'Bosnia', 'and', 'Herzegovina', 'Botswana', 'Bouvet', 'Island', 'Brazil', 'British', 'Indian', 'Ocean', 'Territory', 'Brunei', 'Bulgaria', 'Burkina', 'Faso', 'Burundi', 'Cambodia', 'Cameroon', 'Canada', 'Canary', 'Islands', 'Cape', 'Verde', 'Cayman', 'Islands', 'Central', 'African', 'Republic', 'Chad', 'Chile', 'China', 'Christmas', 'Island', 'Cocos', '(Keeling)', 'Islands', 'Colombia', 'Comoros', 'Congo,', 'Democratic', 'Republic', 'of', 'Congo,', 'Republic', 'of', 'Cook', 'Islands', 'Costa', 'Rica', 'Croatia', 'Cuba', 'Curacao', 'Cyprus', 'Czech', 'Republic', 'Denmark', 'Djibouti', 'Dominica', 'Dominican', 'Republic', 'Ecuador', 'Egypt', 'El', 'Salvador', 'Equatorial', 'Guinea', 'Eritrea', 'Estonia', 'Ethiopia', 'Falkland', 'Islands', 'Faroe', 'Islands', 'Fiji', 'Finland', 'France', 'French', 'Guiana', 'French', 'Polynesia', 'French', 'Southern', 'Lands', 'Gabon', 'Gambia', 'Georgia', 'Germany', 'Ghana', 'Gibraltar', 'Greece', 'Greenland', 'Grenada', 'Guadeloupe', 'Guam', 'Guatemala', 'Guernsey', 'Guinea', 'Guinea-Bissau', 'Guyana', 'Haiti', 'Heard', 'Island', 'and', 'Mcdonald', 'Islands', 'Honduras', 'Hong', 'Kong', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran', 'Iraq', 'Ireland', 'Isle', 'of', 'Man', 'Israel', 'Italy', 'Ivory', 'Coast', 'Jamaica', 'Japan', 'Jersey', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati', 'Kuwait', 'Kyrgyzstan', 'Laos', 'Latvia', 'Lebanon', 'Lesotho', 'Liberia', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Lybia', 'Macao', 'Macedonia', 'Madagascar', 'Malawi', 'Malaysia', 'Maldives', 'Mali', 'Malta', 'Marshall', 'Islands', 'Martinique', 'Mauritania', 'Mauritius', 'Mayotte', 'Mexico', 'Micronesia', 'Moldova', 'Monaco', 'Mongolia', 'Montenegro', 'Montserrat', 'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands', 'Netherlands', 'Antilles', 'New', 'Caledonia', 'New', 'Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'Niue', 'Norfolk', 'Island', 'North', 'Korea', 'Northern', 'Mariana', 'Islands', 'Norway', 'Oman', 'Pakistan', 'Palau', 'Palestine', 'Panama', 'Papua', 'New', 'Guinea', 'Paraguay', 'Peru', 'Philippines', 'Pitcairn', 'Poland', 'Portugal', 'Puerto', 'Rico', 'Qatar', 'Reunion', 'Romania', 'Russia', 'Rwanda', 'Saint', 'Barthélemy', 'Saint', 'Helena', 'Saint', 'Kitts', 'and', 'Nevis', 'Saint', 'Lucia', 'Saint', 'Martin', 'Saint', 'Pierre', 'and', 'Miquelon', 'Saint', 'Vincent', 'Samoa', 'San', 'Marino', 'São', 'Tomé', 'and', 'Príncipe', 'Saudi', 'Arabia', 'Senegal', 'Serbia', 'Seychelles', 'Sierra', 'Leone', 'Singapore', 'Slovakia', 'Slovenia', 'Solomon', 'Islands', 'Somalia', 'South', 'Africa', 'South', 'Georgia', 'and', 'the', 'South', 'Sandwich', 'Islands', 'South', 'Korea', 'South', 'Sudan', 'Spain', 'Sri', 'Lanka', 'Sudan', 'Suriname', 'Svalbard', 'and', 'Jan', 'Mayen', 'Swaziland', 'Sweden', 'Switzerland', 'Syria', 'Taiwan', 'Tajikistan', 'Tanzania', 'Thailand', 'Timor-Leste', 'Togo', 'Tokelau', 'Tonga', 'Trinidad', 'and', 'Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Turks', 'and', 'Caicos', 'Islands', 'Tuvalu', 'Uganda', 'Ukraine', 'United', 'Arab', 'Emirates', 'United', 'Kingdom', 'United', 'States', 'United', 'States', 'Minor', 'Outlying', 'Islands', 'Uruguay', 'Uzbekistan', 'Vanuatu', 'Vatican', 'City', 'Venezuela', 'Vietnam', 'Virgin', 'Islands,', 'British', 'Virgin', 'Islands,', 'U.S.', 'Wallis', 'and', 'Futuna', 'Western', 'Sahara', 'Yemen', 'Zambia', 'Zimbabwe'];
+      loc_parts[1] = loc_parts[1].replace(/\n|\r/g, "").trim();
+      loc_parts[0] = loc_parts[0].replace(/\n|\r/g, "").trim();
+      if (countries.indexOf(loc_parts[1]) !== -1) {
+        region = loc_parts[0];
+        country = loc_parts[1];
+      } else {
         locality = loc_parts[0];
-        region   = loc_parts[1];
-    } else if (1 === loc_parts.length) {
+        region = loc_parts[1];
+      }
+    }
+    else if (1 === loc_parts.length) {
         country = loc_parts[0];
     }
     var profile_data = {

--- a/fetlife-age-sex-location-search.user.js
+++ b/fetlife-age-sex-location-search.user.js
@@ -1,11 +1,11 @@
 /**
- * This is a Greasemonkey script and must be run using a Greasemonkey-compatible browser.
+ * This is a Tempermonkey script and must be run using a Tempermonkey-compatible browser.
  *
  * @author ornias1993 <kjeld@schouten-lebbing.nl>
  */
 // ==UserScript==
 // @name           FetLife ASL Search (Reborn Edition)
-// @version        0.5.3
+// @version        0.5.4
 // @namespace      https://github.com/Ornias1993/fetlife-aslsearch-reborn
 // @updateURL      https://github.com/Ornias1993/fetlife-aslsearch-reborn/raw/master/fetlife-age-sex-location-search.user.js
 // @description    Allows you to search for FetLife profiles based on age, sex, location, and role.

--- a/fetlife-age-sex-location-search.user.js
+++ b/fetlife-age-sex-location-search.user.js
@@ -595,7 +595,7 @@ FL_ASL.createTabList = function () {
     ul.setAttribute('class', 'tabs');
     html_string = '<li data-fl-asl-section-id="fetlife_asl_search_about"><a href="#">About FetLife ASL Search ' + GM_info.script.version + '</a></li>';
     html_string += '<li class="in_section" data-fl-asl-section-id="fetlife_asl_search_extended"><a href="#">Extended A/S/L search</a></li>';
-    html_string += '<li data-fl-asl-section-id="fetlife_asl_search_classic"><a href="#">Legacy Search</a></li>';
+    html_string += '<li data-fl-asl-section-id="fetlife_asl_search_classic" style="display:none"><a href="#">Legacy Search</a></li>';
     ul.innerHTML = html_string;
     ul.addEventListener('click', function (e) {
         var id_to_show = jQuery(e.target.parentNode).data('fl-asl-section-id');

--- a/fetlife-age-sex-location-search.user.js
+++ b/fetlife-age-sex-location-search.user.js
@@ -1123,7 +1123,7 @@ FL_ASL.scrapeProfile = function (user_id) {
     return profile_data;
 }
 FL_ASL.scrapeUserInList = function (node) {
-    // Deal with location inconsistencies.
+    // TODO Deal with location inconsistencies.
     var loc_parts = jQuery(node).find('.fl-member-card__location').first().text().split(', ');
     var locality = ''; var region = ''; var country = '';
     if (2 === loc_parts.length) {

--- a/server/Code.gs
+++ b/server/Code.gs
@@ -74,7 +74,7 @@ function validateScraperInput (obj) {
         }
         break;
       case 'avatar_url':
-        if (obj[k].match(/^https:\/\/flpics[0-9]*\.[a-z]+\.ssl\.fastly\.net/)) {
+        if (obj[k].match(/^https:\/\/pic[0-9]*\.fetlife\.com/)) {
           safe_obj[k] = obj[k];
         }
         break;

--- a/server/Code.gs
+++ b/server/Code.gs
@@ -4,6 +4,7 @@
  * @author <a href="https://maybemaimed.com/tag/fetlife/">maymay</a>
  */
 
+
 function doGet (e) {
   var output;
   switch (e.parameter.action) {

--- a/server/javascript.html
+++ b/server/javascript.html
@@ -162,8 +162,8 @@ function handleSearchSuccess (results, interval_id) {
       if (row[10]) {
         html += '<form action="https://www.tineye.com/search" method="POST" target="_blank"><input type="hidden" name="url" value="' + row[10] + '" /><button type="submit" class="btn btn-info btn-xs" style="width:100%">Find ' + row[1] + '\'s profile pic on other sites</button></form>'
       }
-      var pat_fetlife_form_url = 'https://docs.google.com/spreadsheet/viewform?formkey=dGNVT1kzSzFnOXhHRjh1RnczZVVmMXc6MQ';
-      html += '<a href="' + pat_fetlife_form_url + '&entry_0=' + row[0] + '&entry_1=' + row[1] + '" class="btn btn-danger btn-xs" target="_blank">Report ' + row[1] + ' for predatory behavior</a>';
+      var report_url = 'mailto:caretakers@fetlife.com?SUBJECT=I want to report';
+      html += '<a href="' + report_url + row[1] + '&entry_0=' + row[0] + '&entry_1=' + row[1] + '" class="btn btn-danger btn-xs" target="_blank">Report ' + row[1] + ' to Caretakers</a>';
       html += '</div>';
       return html;
     }

--- a/server/javascript.html
+++ b/server/javascript.html
@@ -1,10 +1,9 @@
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-<script src="//cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>
-<script src="//cdn.datatables.net/plug-ins/1.10.7/integration/bootstrap/3/dataTables.bootstrap.js"></script>
-<script src="//cdn.datatables.net/responsive/1.0.6/js/dataTables.responsive.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/v/bs-3.3.7/jq-3.3.1/dt-1.10.18/b-1.5.6/b-colvis-1.5.6/b-print-1.5.6/r-2.2.2/datatables.min.js"></script>
+
+<!-- TODO replace those they are depricated -->
 <script src="//cdn.datatables.net/colvis/1.1.1/js/dataTables.colVis.js"></script>
 <script src="//cdn.datatables.net/tabletools/2.2.4/js/dataTables.tableTools.js"></script>
+
 <script>
 jQuery(document).ready(function () {
   jQuery('[data-toggle="popover"]').popover();
@@ -162,7 +161,7 @@ function handleSearchSuccess (results, interval_id) {
       if (row[10]) {
         html += '<form action="https://www.tineye.com/search" method="POST" target="_blank"><input type="hidden" name="url" value="' + row[10] + '" /><button type="submit" class="btn btn-info btn-xs" style="width:100%">Find ' + row[1] + '\'s profile pic on other sites</button></form>'
       }
-      var report_url = 'mailto:caretakers@fetlife.com?SUBJECT=I want to report';
+      var report_url = 'mailto:caretakers@fetlife.com?SUBJECT=I want to report ';
       html += '<a href="' + report_url + row[1] + '&entry_0=' + row[0] + '&entry_1=' + row[1] + '" class="btn btn-danger btn-xs" target="_blank">Report ' + row[1] + ' to Caretakers</a>';
       html += '</div>';
       return html;

--- a/server/styles.html
+++ b/server/styles.html
@@ -1,7 +1,7 @@
-<link rel="stylesheet" href="//cdn.datatables.net/1.10.7/css/jquery.dataTables.min.css" />
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" />
-<link rel="stylesheet" href="//cdn.datatables.net/plug-ins/1.10.7/integration/bootstrap/3/dataTables.bootstrap.css" />
-<link rel="stylesheet" href="//cdn.datatables.net/responsive/1.0.6/css/dataTables.responsive.css" />
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs-3.3.7/jq-3.3.1/dt-1.10.18/b-1.5.6/b-colvis-1.5.6/b-print-1.5.6/r-2.2.2/datatables.min.css"/>
+
+<!-- TODO replace those they are depricated -->
+
 <link rel="stylesheet" href="//cdn.datatables.net/colvis/1.1.2/css/dataTables.colVis.css" />
 <link rel="stylesheet" href="//cdn.datatables.net/tabletools/2.2.4/css/dataTables.tableTools.css" />
 <style>


### PR DESCRIPTION
This pushes all changes for 0.5.4 client and all recently implemented server fixes to master.

    * [Feature Hidden](https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/7): Legacy search is hidden due to fetlife banhammer and numerous bugs
    * [Bugfix](https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/15): Fixed processing of Avatar url's for extended search. Still cant display them in results
    * [Misc] (https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/17): Replaced FAADE report with "Report User to Caretakes" in search results
    * [Bugfix](https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/18): Fixed Country and Region mixup during scraping and database corrupt. Database will recover in time.
    * [Documentation](https://github.com/Ornias1993/fetlife-aslsearch-reborn/issues/20): Pointed towards tampermonkey instead of greasemonkey due to compatibility issues
    * update: Updated and consolidated server Scripts and (external) CSS